### PR TITLE
fixed news landing page query to match stg and prod

### DIFF
--- a/lib/graphql-api/queries/news.ts
+++ b/lib/graphql-api/queries/news.ts
@@ -86,24 +86,22 @@ export async function getNewsLandingPageSettings(): Promise<any> {
     `query getNewsLandingPageSettings {
       newsPageSettings {
         newsLanding {
-          socialMediaShare {
-            description
-            descriptionMn
-            title
-            titleMn
-            image {
-              mediaItemUrl
-            }
-            imageMn {
-              mediaItemUrl
-              }
+          description
+          descriptionMn
+          title
+          titleMn
+          image {
+            mediaItemUrl
+          }
+          imageMn {
+            mediaItemUrl
             }
           }
         }
       }
     `,
   )
-  return data.newsPageSettings.newsLanding.socialMediaShare || []
+  return data.newsPageSettings.newsLanding || []
 }
 
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -48,7 +48,7 @@ function MyApp({ Component, pageProps }: AppProps) {
           <meta name="keywords" content="air pollution, clean air, public health, mongolia"></meta>
 
           <title>{title}</title>
-          <meta property="og:description" content=" " />
+          <meta property="og:description" content="&nbsp;" />
           <meta property="og:title" content={title} />
           <meta property="og:image" content={image} />
           <meta name="description" content={description} />


### PR DESCRIPTION
Added placeholder for the og:description meta tag so it doesn't show. The plain description tag is still there for SEO.