### PR TITLE
external news language support

### DIFF
--- a/components/Cards/NewsCards/NewsCard.tsx
+++ b/components/Cards/NewsCards/NewsCard.tsx
@@ -43,6 +43,11 @@ export const NewsCard = ({
     if (transformedNews.newsContentType) {
       switch (transformedNews.newsContentType.toLowerCase()) {
         case 'external':
+          if (i18n.language !== transformedNews.sourceLanguage) {
+            router.push(`/news/${transformedNews.desiredSlug || transformedNews.slug || transformedNews.id}`)
+            return
+          }
+
           window.open(transformedNews.sourceLink, '_blank')
           return
         case 'video':

--- a/graphql/generated.ts
+++ b/graphql/generated.ts
@@ -2966,6 +2966,41 @@ export type GeneralSettings = {
   url?: Maybe<Scalars['String']>;
 };
 
+/** Health Page Settings options */
+export type HealthPageSettings = {
+  __typename?: 'HealthPageSettings';
+  healthPage?: Maybe<HealthPageSettings_Healthpage>;
+  pageSlug?: Maybe<Scalars['String']>;
+  pageTitle?: Maybe<Scalars['String']>;
+};
+
+/** Field Group */
+export type HealthPageSettings_Healthpage = {
+  __typename?: 'HealthPageSettings_Healthpage';
+  body?: Maybe<Scalars['String']>;
+  bodyMn?: Maybe<Scalars['String']>;
+  diagramTextBottom?: Maybe<Scalars['String']>;
+  diagramTextBottomMn?: Maybe<Scalars['String']>;
+  diagramTextTop?: Maybe<Scalars['String']>;
+  diagramTextTopMn?: Maybe<Scalars['String']>;
+  fieldGroupName?: Maybe<Scalars['String']>;
+  healthSocialMediaShare?: Maybe<HealthPageSettings_Healthpage_HealthSocialMediaShare>;
+  title?: Maybe<Scalars['String']>;
+  titleMn?: Maybe<Scalars['String']>;
+};
+
+/** Field Group */
+export type HealthPageSettings_Healthpage_HealthSocialMediaShare = {
+  __typename?: 'HealthPageSettings_Healthpage_HealthSocialMediaShare';
+  description?: Maybe<Scalars['String']>;
+  descriptionMn?: Maybe<Scalars['String']>;
+  fieldGroupName?: Maybe<Scalars['String']>;
+  image?: Maybe<MediaItem>;
+  imageMn?: Maybe<MediaItem>;
+  title?: Maybe<Scalars['String']>;
+  titleMn?: Maybe<Scalars['String']>;
+};
+
 /** Content node with hierarchical (parent/child) relationships */
 export type HierarchicalContentNode = {
   /** Returns ancestors of the node. Default ordered as lowest (closest to the child) to highest (closest to the root). */
@@ -3997,6 +4032,12 @@ export enum MimeTypeEnum {
   ImageGif = 'IMAGE_GIF',
   /** MimeType image/heic */
   ImageHeic = 'IMAGE_HEIC',
+  /** MimeType image/heic-sequence */
+  ImageHeicSequence = 'IMAGE_HEIC_SEQUENCE',
+  /** MimeType image/heif */
+  ImageHeif = 'IMAGE_HEIF',
+  /** MimeType image/heif-sequence */
+  ImageHeifSequence = 'IMAGE_HEIF_SEQUENCE',
   /** MimeType image/jpeg */
   ImageJpeg = 'IMAGE_JPEG',
   /** MimeType image/png */
@@ -7330,6 +7371,8 @@ export type RootQuery = {
   discussionSettings?: Maybe<DiscussionSettings>;
   /** Fields of the &#039;GeneralSettings&#039; settings group */
   generalSettings?: Maybe<GeneralSettings>;
+  /** Health Page Settings options */
+  healthPageSettings?: Maybe<HealthPageSettings>;
   /** Home Page Settings options */
   homePageSettings?: Maybe<HomePageSettings>;
   /** An object of the mediaItem Type.  */

--- a/pages/health/index.tsx
+++ b/pages/health/index.tsx
@@ -50,7 +50,7 @@ export const getStaticProps: GetStaticProps = async ({ locale }) => {
       featuredTakeActions,
       page: page,
       title: getTranslated(page.healthSocialMediaShare.title, page.healthSocialMediaShare.titleMn, locale),
-      image: getTranslated(page.healthSocialMediaShare.image.mediaItemUrl, page.healthSocialMediaShare.imageMn.mediaItemUrl, locale),
+      image: getTranslated(page.healthSocialMediaShare.image?.mediaItemUrl, page.healthSocialMediaShare.imageMn?.mediaItemUrl, locale),
     },
     // This tells the page how often to refetch from the API (in seconds) (1 hour)
     revalidate: 60 * 60,


### PR DESCRIPTION
# Summary\*

When clicking on external news from a language different than the source language, it will open an original article instead of redirecting to the source link.
