### PR TITLE
Fix policy page styles

### DIFF
--- a/components/HomePage/TakeActionCarousel.tsx
+++ b/components/HomePage/TakeActionCarousel.tsx
@@ -17,14 +17,17 @@ export const TakeActionCarousel = ({
 }) => {
   const { t } = useTranslation('home')
 
+  // Check if we have fewer than 4 cards
+  const hasFewerThanFourCards = takeActionPosts.length < 4
+
   // Styling the settings for take-action-carousel within Slider
   const settings = {
     dots: false,
-    infinite: true,
+    infinite: !hasFewerThanFourCards,
     speed: 600,
-    slidesToShow: 4,
-    slidesToScroll: 2,
-    arrows: true,
+    slidesToShow: hasFewerThanFourCards ? takeActionPosts.length : 4,
+    slidesToScroll: hasFewerThanFourCards ? 1 : 2,
+    arrows: !hasFewerThanFourCards,
     autoplaySpeed: 5000,
     cssEase: 'ease-in-out',
     adaptiveHeight: true,
@@ -34,17 +37,17 @@ export const TakeActionCarousel = ({
       {
         breakpoint: 1024,
         settings: {
-          slidesToShow: 5,
-          slidesToScroll: 2,
-          infinite: true,
+          slidesToShow: hasFewerThanFourCards ? takeActionPosts.length : 5,
+          slidesToScroll: hasFewerThanFourCards ? 1 : 2,
+          infinite: !hasFewerThanFourCards,
         },
       },
       {
         breakpoint: 600,
         settings: {
-          slidesToShow: 3,
+          slidesToShow: hasFewerThanFourCards ? takeActionPosts.length : 3,
           slidesToScroll: 1,
-          initialSlide: 2,
+          initialSlide: hasFewerThanFourCards ? 0 : 2,
         },
       },
       {
@@ -70,14 +73,18 @@ export const TakeActionCarousel = ({
       <Slider
         {...settings}
         prevArrow={
-          <Arrow check={0} classes="prev-gray-arrow">
-            <ChevronLeftIcon className="w-8 h-8 text-white" />
-          </Arrow>
+          hasFewerThanFourCards ? <></> : (
+            <Arrow check={0} classes="prev-gray-arrow">
+              <ChevronLeftIcon className="w-8 h-8 text-white" />
+            </Arrow>
+          )
         }
         nextArrow={
-          <Arrow check={takeActionPosts?.length - 4} classes="next-gray-arrow">
-            <ChevronRightIcon className="w-8 h-8 text-white" />
-          </Arrow>
+          hasFewerThanFourCards ? <></> : (
+            <Arrow check={takeActionPosts?.length - 4} classes="next-gray-arrow">
+              <ChevronRightIcon className="w-8 h-8 text-white" />
+            </Arrow>
+          )
         }
       >
         {takeActionPosts.map((takeAction, idx) => (

--- a/components/PolicyPage/PolicyCard.tsx
+++ b/components/PolicyPage/PolicyCard.tsx
@@ -3,10 +3,12 @@ import { ChevronDownIcon, ChevronUpIcon } from '@heroicons/react/24/solid'
 import { useTranslation } from 'next-i18next'
 import { getTranslated } from 'lib/utils/getTranslated'
 import { formatDate, translateList } from 'lib/utils/policy'
+import Link from 'next/link'
 
 interface PolicyCardProps {
   policy: {
     databaseId: string
+    slug: string
     dateGmt: string
     policyPageCustomFields: {
       title: string
@@ -23,16 +25,18 @@ export const PolicyEntry = ({ policy, locale }: PolicyCardProps) => {
   const [isTagsExpanded, setIsTagsExpanded] = useState(false)
   const { t } = useTranslation('policy')
   const { title, titleMn } = policy.policyPageCustomFields
-  const { topics, dateGmt } = policy
+  const { topics, dateGmt, slug } = policy
   const dateApproved = formatDate(dateGmt)
   const transformedTopics = translateList((topics?.edges || []).map((e: any) => e.node.name), locale)
 
   return (
     <div className="pb-2 mb-4 border-b-2 border-gray-200 last:border-b-0">
-      <div
-        className="text-bm-blue leading-relaxed prose max-w-none mb-3"
-        dangerouslySetInnerHTML={{ __html: getTranslated(title, titleMn, locale) }}
-      />
+      <Link href={`/policy/${slug}`} className="block">
+        <div
+          className="text-bm-blue hover:text-blue-600 transition-colors leading-relaxed prose max-w-none mb-3 cursor-pointer"
+          dangerouslySetInnerHTML={{ __html: getTranslated(title, titleMn, locale) }}
+        />
+      </Link>
       <div className='flex justify-between items-center'>
         <div className='bg-gray-200 rounded-lg text-xs px-4 py-2'>{t('approvedOn')}: {dateApproved}</div>
         

--- a/components/PolicyPage/RelatedPoliciesList.tsx
+++ b/components/PolicyPage/RelatedPoliciesList.tsx
@@ -6,6 +6,7 @@ import { PolicyEntry } from './PolicyCard'
 interface RelatedPoliciesListProps {
   policies: Array<{
     databaseId: string
+    slug: string
     dateGmt: string
     policyPageCustomFields: {
       title: string

--- a/pages/policy/[slug].tsx
+++ b/pages/policy/[slug].tsx
@@ -87,8 +87,6 @@ export default function PolicyPostPage({ policy, locale, slug, error }: PolicyPo
   const status = translateList(policy.status || [], locale)
   const relatedPolicies = policy.relatedPolicies
 
-
-  console.log("furtherReading:", furtherReading);
   return (
     <div className="max-w-5xl mx-auto px-4 py-10">
       {/* Back Link */}

--- a/pages/policy/[slug].tsx
+++ b/pages/policy/[slug].tsx
@@ -39,6 +39,7 @@ interface Policy {
 
 interface RelatedPolicy {
   databaseId: string
+  slug: string
   dateGmt: string
   policyPageCustomFields: {
     title: string
@@ -86,6 +87,8 @@ export default function PolicyPostPage({ policy, locale, slug, error }: PolicyPo
   const status = translateList(policy.status || [], locale)
   const relatedPolicies = policy.relatedPolicies
 
+
+  console.log("furtherReading:", furtherReading);
   return (
     <div className="max-w-5xl mx-auto px-4 py-10">
       {/* Back Link */}
@@ -263,7 +266,7 @@ export default function PolicyPostPage({ policy, locale, slug, error }: PolicyPo
       {/* Further Reading */}
       <H2 title={t('furtherReadingTitle')} trailingLineColor="blue" className="!text-lg" />
       <div
-        className="text-bm-blue leading-relaxed policy-list-content mb-8"
+        className="text-gray-700 leading-relaxed policy-list-content mb-8"
         dangerouslySetInnerHTML={{ __html: furtherReading }}
       />
 

--- a/styles/index.scss
+++ b/styles/index.scss
@@ -39,10 +39,17 @@ figure {
     margin-left: 0.5rem;
     padding-left: 1rem;
   }
-  
+
   li {
     display: list-item;
     margin-bottom: 0.5rem;
+  }
+
+  a {
+    @apply text-blue-600 underline;
+    &:hover {
+      @apply text-blue-400;
+    }
   }
 }
 


### PR DESCRIPTION
# Summary\*

`Changes`: List out any important changes here

# This PR includes the following changes\*

- left align take action carousel when there is less then 4 cards
- remove blue text styling from Further reading
- support hyperlink in Futher reading
- make related policies clickable

