### PR TITLE
Fix: search error code 404

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,6 +8,7 @@
 - [ ] fix: bug fix
 - [ ] refactor: refactoring of existing code
 - [ ] cleanup: cleanup of unnecessary or obsolete code
+- [ ] test: added or updated tests
 
 # Reference(s)\*
 

--- a/components/SearchPage/News.tsx
+++ b/components/SearchPage/News.tsx
@@ -6,11 +6,11 @@ import Desktop from 'components/Desktop'
 import Mobile from 'components/Mobile'
 
 const News: FC<{ data: any[] }> = ({ data: newsData }) => {
-  const [t, i18n] = useTranslation('search')
+  const { t } = useTranslation('search')
+  const [currentPage, setCurrentPage] = useState(1)
   if (newsData.length === 0) return null
 
   const cardsPerPage = 6
-  const [currentPage, setCurrentPage] = useState(1)
   const indexOfLastOrg = currentPage * cardsPerPage
   const indexOfFirstOrg = indexOfLastOrg - cardsPerPage
 
@@ -36,7 +36,7 @@ const News: FC<{ data: any[] }> = ({ data: newsData }) => {
               categories={data.categories}
               newsContentType={data.newsContentType}
               newsLandingPageFeatured={data.newsLandingPageFeatured}
-              featuredImageSmall={data.featuredImageBig || data.featuredImageSmall || data.featuredImage}
+              featuredImageSmall={data.featuredImageBig || data.featuredImageSmall}
               cName=""
             />
           ))}

--- a/components/SearchPage/Policies.tsx
+++ b/components/SearchPage/Policies.tsx
@@ -4,9 +4,9 @@ import { PolicyEntry } from 'components/PolicyPage/PolicyCard'
 
 const Policies: FC<{ data: any[] }> = ({ data: policyData }) => {
   const { t, i18n } = useTranslation(['search', 'policy'])
+  const [isExpanded, setIsExpanded] = useState(false)
   if (policyData.length === 0) return null
 
-  const [isExpanded, setIsExpanded] = useState(false)
   const initialDisplayCount = 5
   const shouldShowToggle = policyData.length > initialDisplayCount
 
@@ -18,11 +18,7 @@ const Policies: FC<{ data: any[] }> = ({ data: policyData }) => {
 
       <div className="policy-results">
         {displayedPolicies.map((policy: any, index: number) => (
-          <PolicyEntry
-            key={policy.databaseId || index}
-            policy={policy}
-            locale={i18n.language}
-          />
+          <PolicyEntry key={policy.databaseId || index} policy={policy} locale={i18n.language} />
         ))}
       </div>
 

--- a/components/SearchPage/TakeActions.tsx
+++ b/components/SearchPage/TakeActions.tsx
@@ -28,9 +28,9 @@ type Props = {
 
 const TakeActions: FC<Props> = ({ takeActions }) => {
   const { t } = useTranslation('search')
+  const [currentPage, setCurrentPage] = useState(1)
   if (takeActions?.length === 0) return null
   const cardsPerPage = 8
-  const [currentPage, setCurrentPage] = useState(1)
   const indexOfLastOrg = currentPage * cardsPerPage
   const indexOfFirstOrg = indexOfLastOrg - cardsPerPage
 

--- a/components/SearchPage/Teams.tsx
+++ b/components/SearchPage/Teams.tsx
@@ -68,11 +68,11 @@ const settings = {
 }
 
 const Teams: FC<Props> = ({ people }) => {
-  const [t, i18n] = useTranslation('search')
+  const { t } = useTranslation('search')
+  const [currentPage, setCurrentPage] = useState(1)
   if (people.length === 0) return null
 
   const cardsPerPage = 3
-  const [currentPage, setCurrentPage] = useState(1)
   const indexOfLastOrg = currentPage * cardsPerPage
   const indexOfFirstOrg = indexOfLastOrg - cardsPerPage
 

--- a/lib/graphql-api/queries/search.ts
+++ b/lib/graphql-api/queries/search.ts
@@ -129,12 +129,6 @@ export async function getSearchData() {
               captionMn
             }
             }
-            featuredImage {
-              node {
-                  id
-                  mediaItemUrl
-              }
-            }
             categories {
             nodes {
                 categoryCustomFields {

--- a/pages/news/[slug].tsx
+++ b/pages/news/[slug].tsx
@@ -10,12 +10,7 @@ import { H2 } from 'components/generic/Typography'
 import { removeTags } from 'lib/utils/htmlParser'
 
 import { getImage } from 'lib/utils/getImage'
-import {
-  getNewsBannerImages,
-  getNewsFull,
-  getNewsPostSlugs,
-  getLastThree,
-} from 'lib/graphql-api/queries/news'
+import { getNewsBannerImages, getNewsFull, getNewsPostSlugs, getLastThree } from 'lib/graphql-api/queries/news'
 import { BreadCrumb, ShareButton, LatestNews, Banner } from 'components/NewsPage/DetailPage'
 import LoadingPage from 'components/generic/LoadingPage'
 
@@ -36,8 +31,6 @@ export default function NewsPostPage({ post, bannerImage, bannerText, getLatest 
   if (!post || !post?.slug) {
     return <ErrorPage statusCode={404} />
   }
-
-  console.log(post)
 
   const { t } = useTranslation('news')
 
@@ -196,10 +189,10 @@ const getTransformedData = (banner: any, locale: string) => {
         locale,
       ) !== null
         ? getTranslated(
-          banner?.newsGeneralFields.banner?.bannerImage?.node?.mediaItemUrl,
-          banner?.newsGeneralFields.banner?.bannerImageMn?.node?.mediaItemUrl,
-          locale,
-        )
+            banner?.newsGeneralFields.banner?.bannerImage?.node?.mediaItemUrl,
+            banner?.newsGeneralFields.banner?.bannerImageMn?.node?.mediaItemUrl,
+            locale,
+          )
         : '',
   }
 }
@@ -229,14 +222,14 @@ const getNews = (news: News, locale: string): any => {
     authors:
       news?.newsCustomFields.authors !== null
         ? news?.newsCustomFields.authors?.map((author: any) => {
-          return {
-            name:
-              getTranslated(author.authorName, author.authorNameMn, locale) !== null
-                ? getTranslated(author.authorName, author.authorNameMn, locale)
-                : '',
-            authorLink: author.authorLink,
-          }
-        })
+            return {
+              name:
+                getTranslated(author.authorName, author.authorNameMn, locale) !== null
+                  ? getTranslated(author.authorName, author.authorNameMn, locale)
+                  : '',
+              authorLink: author.authorLink,
+            }
+          })
         : null,
     categories: news?.categories?.nodes.map((cat: any) => {
       return {
@@ -253,7 +246,11 @@ const getNews = (news: News, locale: string): any => {
       null,
       'large',
     ),
-    caption: getTranslated(news.newsCustomFields.featuredImage.caption, news.newsCustomFields.featuredImage.captionMn, locale),
+    caption: getTranslated(
+      news.newsCustomFields.featuredImage.caption,
+      news.newsCustomFields.featuredImage.captionMn,
+      locale,
+    ),
   }
 }
 

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -25,15 +25,15 @@ const SearchPage = ({ data, locale, banner }) => {
   const pageBanner =
     i18n.language === 'en'
       ? {
-        imageUrl: banner.bannerimage?.node.mediaItemUrl,
-        leftText: banner.bannerTextLeft,
-        rightText: getBannerTextRight(banner.bannerTextRight, 'categoryText'),
-      }
+          imageUrl: banner.bannerimage?.node.mediaItemUrl,
+          leftText: banner.bannerTextLeft,
+          rightText: getBannerTextRight(banner.bannerTextRight, 'categoryText'),
+        }
       : {
-        imageUrl: banner.bannerimageMn?.node.mediaItemUrl,
-        leftText: banner.bannerTextLeftMn,
-        rightText: getBannerTextRight(banner.bannerTextRight, 'categoryTextMn'),
-      }
+          imageUrl: banner.bannerimageMn?.node.mediaItemUrl,
+          leftText: banner.bannerTextLeftMn,
+          rightText: getBannerTextRight(banner.bannerTextRight, 'categoryTextMn'),
+        }
 
   if (searchValue === '') {
     return (
@@ -91,16 +91,15 @@ const SearchPage = ({ data, locale, banner }) => {
         featuredImageSmall: getImage(
           news.node.newsCustomFields.featuredImage.image?.mediaDetails,
           news.node.newsCustomFields.featuredImage.imageMn?.mediaDetails,
-          news.node.featuredImage?.node?.mediaDetails,
+          null,
           'medium',
         ),
         featuredImageBig: getImage(
           news.node.newsCustomFields.featuredImage.image?.mediaDetails,
           news.node.newsCustomFields.featuredImage.imageMn?.mediaDetails,
-          news.node.featuredImage?.node?.mediaDetails,
+          null,
           'medium_large',
         ),
-        featuredImage: news.node.featuredImage?.node.mediaItemUrl,
       })
     })
     return newsData
@@ -118,23 +117,37 @@ const SearchPage = ({ data, locale, banner }) => {
         slug: takeAction.node.slug,
         date: takeAction.node.dateGmt,
         title:
-          getTranslated(takeAction.node.takeActionCustomFields.title, takeAction.node.takeActionCustomFields.titleMn) !== null
-            ? getTranslated(takeAction.node.takeActionCustomFields.title, takeAction.node.takeActionCustomFields.titleMn, locale)
+          getTranslated(
+            takeAction.node.takeActionCustomFields.title,
+            takeAction.node.takeActionCustomFields.titleMn,
+          ) !== null
+            ? getTranslated(
+                takeAction.node.takeActionCustomFields.title,
+                takeAction.node.takeActionCustomFields.titleMn,
+                locale,
+              )
             : '',
         excerpt:
-          getTranslated(takeAction.node.takeActionCustomFields.excerpt, takeAction.node.takeActionCustomFields.excerptMn) !== null
-            ? getTranslated(takeAction.node.takeActionCustomFields.excerpt, takeAction.node.takeActionCustomFields.excerptMn, locale)
+          getTranslated(
+            takeAction.node.takeActionCustomFields.excerpt,
+            takeAction.node.takeActionCustomFields.excerptMn,
+          ) !== null
+            ? getTranslated(
+                takeAction.node.takeActionCustomFields.excerpt,
+                takeAction.node.takeActionCustomFields.excerptMn,
+                locale,
+              )
             : '',
         additionalResources:
           takeAction.node.takeActionCustomFields.additionalResources != null
             ? takeAction.node.takeActionCustomFields.additionalResources.map(
-              (resource: { title: string; titleMn: string; url: string; urlMn: string }) => {
-                return {
-                  title: getTranslated(resource.title, resource.titleMn),
-                  url: getTranslated(resource.url, resource.urlMn, locale),
-                }
-              },
-            )
+                (resource: { title: string; titleMn: string; url: string; urlMn: string }) => {
+                  return {
+                    title: getTranslated(resource.title, resource.titleMn),
+                    url: getTranslated(resource.url, resource.urlMn, locale),
+                  }
+                },
+              )
             : [],
         pledgeContent: getTranslated(
           takeAction.node.takeActionCustomFields.pledgeContent,
@@ -215,38 +228,38 @@ const SearchPage = ({ data, locale, banner }) => {
     searchValue === ''
       ? newses
       : newses.filter(
-        item =>
-          item.title?.toLocaleLowerCase().includes(searchValue.toLocaleLowerCase()) ||
-          item.body?.toLocaleLowerCase().includes(searchValue.toLocaleLowerCase()),
-      )
+          item =>
+            item.title?.toLocaleLowerCase().includes(searchValue.toLocaleLowerCase()) ||
+            item.body?.toLocaleLowerCase().includes(searchValue.toLocaleLowerCase()),
+        )
 
   const newFilteredTakeActions =
     searchValue === ''
       ? takeActions
       : takeActions.filter(
-        takeAction =>
-          takeAction.title?.toLocaleLowerCase().includes(searchValue.toLocaleLowerCase()) ||
-          takeAction.pledgeContent?.toLocaleLowerCase().includes(searchValue.toLocaleLowerCase()) ||
-          takeAction.excerpt?.toLocaleLowerCase().includes(searchValue.toLocaleLowerCase()),
-      )
+          takeAction =>
+            takeAction.title?.toLocaleLowerCase().includes(searchValue.toLocaleLowerCase()) ||
+            takeAction.pledgeContent?.toLocaleLowerCase().includes(searchValue.toLocaleLowerCase()) ||
+            takeAction.excerpt?.toLocaleLowerCase().includes(searchValue.toLocaleLowerCase()),
+        )
 
   const filteredPeople =
     searchValue === ''
       ? people
       : people.filter(
-        item =>
-          item.name?.toLocaleLowerCase().includes(searchValue.toLocaleLowerCase()) ||
-          item.description?.toLocaleLowerCase().includes(searchValue.toLocaleLowerCase()),
-      )
+          item =>
+            item.name?.toLocaleLowerCase().includes(searchValue.toLocaleLowerCase()) ||
+            item.description?.toLocaleLowerCase().includes(searchValue.toLocaleLowerCase()),
+        )
 
   const filteredPolicies =
     searchValue === ''
       ? policies
       : policies.filter(policy =>
-        Object.values(policy.searchableText).some((text: string) =>
-          text?.toLowerCase().includes(searchValue.toLowerCase()),
-        ),
-      )
+          Object.values(policy.searchableText).some((text: string) =>
+            text?.toLowerCase().includes(searchValue.toLowerCase()),
+          ),
+        )
 
   const count = filteredPolicies.length + filteredNews.length + filteredPeople.length + newFilteredTakeActions.length
 

--- a/tests/e2e/pages/search/search.spec.ts
+++ b/tests/e2e/pages/search/search.spec.ts
@@ -1,0 +1,110 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Search Page', () => {
+  test('should load the search page without errors', async ({ page }) => {
+    const response = await page.goto('/en/search', {
+      waitUntil: 'domcontentloaded',
+      timeout: 0,
+    })
+
+    expect(response?.status()).toBe(200)
+  })
+
+  test('should display the search bar', async ({ page }) => {
+    await page.goto('/en/search', {
+      waitUntil: 'domcontentloaded',
+      timeout: 0,
+    })
+
+    const searchInput = page.locator('.search-form input[type="text"]')
+    await expect(searchInput).toBeVisible()
+  })
+
+  test('should display search results when a query is provided', async ({ page }) => {
+    await page.goto('/en/search?s=air', {
+      waitUntil: 'domcontentloaded',
+      timeout: 0,
+    })
+
+    const searchResult = page.locator('.search-result')
+    await expect(searchResult).toBeVisible()
+    await expect(searchResult).toContainText('search results for')
+    await expect(searchResult).toContainText('"air"')
+  })
+
+  test('should show result count when searching', async ({ page }) => {
+    await page.goto('/en/search?s=air', {
+      waitUntil: 'domcontentloaded',
+      timeout: 0,
+    })
+
+    const resultCount = page.locator('.search-result b').first()
+    await expect(resultCount).toBeVisible()
+
+    const countText = await resultCount.innerText()
+    const count = parseInt(countText)
+    expect(count).toBeGreaterThanOrEqual(0)
+  })
+
+  test('should navigate to search results when pressing Enter', async ({ page }) => {
+    await page.goto('/en/search', {
+      waitUntil: 'domcontentloaded',
+      timeout: 0,
+    })
+
+    const searchInput = page.locator('.search-form input[type="text"]')
+    await searchInput.fill('Mongolia')
+    await searchInput.press('Enter')
+
+    await page.waitForURL(/\/search\?s=Mongolia/)
+    await expect(page.locator('.search-result')).toContainText('"Mongolia"')
+  })
+
+  test('should navigate to search results when clicking the search button', async ({ page }) => {
+    await page.goto('/en/search', {
+      waitUntil: 'domcontentloaded',
+      timeout: 0,
+    })
+
+    const searchInput = page.locator('.search-form input[type="text"]')
+    await searchInput.fill('pollution')
+
+    const searchButton = page.locator('.search-btn')
+    await searchButton.click()
+
+    await page.waitForURL(/\/search\?s=pollution/)
+    await expect(page.locator('.search-result')).toContainText('"pollution"')
+  })
+
+  test('should not show results section when search query is empty', async ({ page }) => {
+    await page.goto('/en/search', {
+      waitUntil: 'domcontentloaded',
+      timeout: 0,
+    })
+
+    const searchResult = page.locator('.search-result')
+    await expect(searchResult).toBeEmpty()
+  })
+
+  test('should work in Mongolian locale', async ({ page }) => {
+    const response = await page.goto('/mn/search?s=агаар', {
+      waitUntil: 'domcontentloaded',
+      timeout: 0,
+    })
+
+    expect(response?.status()).toBe(200)
+
+    const searchResult = page.locator('.search-result')
+    await expect(searchResult).toBeVisible()
+    await expect(searchResult).toContainText('"агаар"')
+  })
+
+  test('should have correct page title', async ({ page }) => {
+    await page.goto('/en/search?s=test', {
+      waitUntil: 'domcontentloaded',
+      timeout: 0,
+    })
+
+    await expect(page).toHaveTitle('Search Results - Breathe Mongolia')
+  })
+})


### PR DESCRIPTION
# Summary

`Changes`: Search page returned 404 because the GraphQL query referenced a featuredImage field removed from the News type. Other queries were updated at the time, but search.ts was missed.

- Removed invalid featuredImage from the newses GraphQL query in the search endpoint
- Removed all stale featuredImage references from the search page data transformation
- Fixed React hooks ordering in 4 search components (News, TakeActions, Teams, Policies) by moving useState calls before early returns
- Removed unused i18n destructures in News and Teams components
- Added Playwright e2e tests for the search page
- Updated PR template
- The screen shot below doesn't show images correctly. That's because we have devl and prod configuration inconsistency. I suggest managing through IaC will help testing much easier. But, I verified that images were there in prod. 

# This PR includes the following changes\*

- [ ] feat: New Feature or update to existing feature
- [x] fix: bug fix
- [x] refactor: refactoring of existing code
- [x] cleanup: cleanup of unnecessary or obsolete code

# Reference(s)\*

Add the below links if applicable

- Airtable Link: [Airtable-###]()
- Figma Link: [Design Link]()

## Screenshots/Demo

**Search and News Data Handling:**

<img width="877" height="906" alt="Screenshot 2026-03-07 at 10 09 03 PM" src="https://github.com/user-attachments/assets/75d22d62-607f-4839-8e98-08198a6476e2" />